### PR TITLE
Add tzdata into final image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN mkdir /user \
     && echo 'nobody:x:65534:65534:nobody:/:' > /user/passwd \
     && echo 'nobody:x:65534:' > /user/group
 
-RUN apk add --no-cache ca-certificates git
+RUN apk add --no-cache ca-certificates git tzdata
 RUN go get -u github.com/golang/dep/cmd/dep
 
 WORKDIR ${GOPATH}/src/github.com/hiddeco/cronjobber
@@ -41,6 +41,7 @@ LABEL maintainer="Hidde Beydals <hello@hidde.co>" \
       org.label-schema.vendor="Hidde Beydals"
 
 COPY --from=builder /user/group /user/passwd /etc/
+COPY --from=builder /usr/share/zoneinfo /usr/share/zoneinfo
 COPY --from=builder /cronjobber /cronjobber
 
 USER nobody:nobody


### PR DESCRIPTION
Without either the `zoneinfo.zip` file or the zoneinfo package content (which should be better maintained than the Go's ZIP file) on the final image, the error listed below is logged, UTC is used and no warnings about this defaulting are issued per the logic on [this function](https://github.com/hiddeco/cronjobber/blob/06a70e0796c52b0d1b04197742f46afbcc918a2d/pkg/controller/cronjobber/utils.go#L207).

```
{"level":"debug","ts":"2019-05-07T03:07:10.545Z","logger":"event-broadcaster","caller":"cronjobber/controller.go:81","msg":"Event(v1.ObjectReference{Kind:\"TZCronJob\", Namespace:\"mynamespace\", Name:\"myapp\", UID:\"1e0b63b6-701d-11e9-a10e-ac1f6b6f8b74\", APIVersion:\"cronjobber.hidde.co/v1alpha1\", ResourceVersion:\"38138966\", FieldPath:\"\"}): type: 'Warning' reason: 'InvalidTimeZone' Attempted to run a job with an invalid time zone: America/New_York. open /usr/local/go/lib/time/zoneinfo.zip: no such file or directory"}
```

[This piece of Go's documentation](https://golang.org/pkg/time/#LoadLocation) explains the loading order of preference for tzdata.

The present commit should include the tzdata content in the uncompressed (and hopefully most updated) format and fix this error that is only detected on the final image, not being covered by the unit tests.