### PR TITLE
UpdateTZ - Init container to make sure that tz db is up to date

### DIFF
--- a/deploy/deploy-updatetz.yaml
+++ b/deploy/deploy-updatetz.yaml
@@ -21,6 +21,29 @@ spec:
       volumes:
       - name: timezonedb
         emptyDir: {}
+      initContainers:
+      - name: init-updatetz
+        image: quay.io/hiddeco/cronjobber-updatetz:0.1.1
+        # NB: the security context configuration below may not work
+        # out of the box on OpenShift
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+        resources:
+          limits:
+            cpu: 100m
+            memory: 64Mi
+        volumeMounts:
+        - name: timezonedb
+          mountPath: /tmp/zoneinfo
+          readOnly: false
+        env:
+        - name: INIT_CONTAINER
+          value: "true"
+        - name: REFRESH_INTERVAL
+          value: "3s"
       containers:
       - name: cronjobber
         image: quay.io/hiddeco/cronjobber:0.2.0
@@ -35,7 +58,7 @@ spec:
           mountPath: /usr/share/zoneinfo
           readOnly: true
       - name: updatetz
-        image: quay.io/hiddeco/cronjobber-updatetz:0.1.0
+        image: quay.io/hiddeco/cronjobber-updatetz:0.1.1
         # NB: the security context configuration below may not work
         # out of the box on OpenShift
         securityContext:

--- a/updatetz/CHANGELOG.md
+++ b/updatetz/CHANGELOG.md
@@ -1,7 +1,7 @@
+## 0.1.1 (TBA)
+
+[Make sure that updatetz runs at least once before pod starts.](https://github.com/hiddeco/cronjobber/issues/24) ([@fethiozdol](https://github.com/fethiozdol))
+
 ## 0.1.0 (2019-05-10)
 
 First semver release.
-
-## 0.1.1 (2020-05-19)
-
-[Make sure that updatetz runs at least once before pod starts.](https://github.com/hiddeco/cronjobber/issues/24) ([@fethiozdol](https://github.com/fethiozdol))

--- a/updatetz/CHANGELOG.md
+++ b/updatetz/CHANGELOG.md
@@ -1,3 +1,7 @@
 ## 0.1.0 (2019-05-10)
 
 First semver release.
+
+## 0.1.1 (2020-05-19)
+
+[Make sure that updatetz runs at least once before pod starts.](https://github.com/hiddeco/cronjobber/issues/24) ([@fethiozdol](https://github.com/fethiozdol))

--- a/updatetz/docker-entrypoint.sh
+++ b/updatetz/docker-entrypoint.sh
@@ -25,10 +25,16 @@ retry() {
 			return 1
 		fi
 	done
+	touch /tmp/updatetz_atleastonce_ok
 }
 
+rm -f /tmp/updatetz_atleastonce_ok
+INIT_CONTAINER="${INIT_CONTAINER:-false}"
 retry updatetz.sh
 while true; do
+	if [ "true" = "$INIT_CONTAINER" ] && [ -f /tmp/updatetz_atleastonce_ok ]; then # Update TZ db only once as an init container if set as "true"
+		exit 0
+	fi
 	sleep "${REFRESH_INTERVAL:=7d}"
 	retry updatetz.sh
 done


### PR DESCRIPTION
Although I couldn't prove yet, this should fix #24 because this PR introduces updatetz to be an additional init container and the init container ensures that the Time Zone database is updated at least once before cronjobber starts.

I've updated the version to 0.1.1 but the docker image is not built (I presume the owner will build it).

Below is the outcome of the test I performed for this PR (some details are masked):

**describe pod after deployment**
```
fethi.ozdol$ kubectl describe pod cronjobber-yyyyyyyyyyyy -c init-updatetz
Events:
  Type    Reason     Age   From                                                 Message
  ----    ------     ----  ----                                                 -------
  Normal  Pulling    16s   kubelet, xxxxxxxxx  Pulling image "xxxxxxxxx/cronjobber-updatetz:0.1.1"
  Normal  Pulled     15s   kubelet, xxxxxxxxx  Successfully pulled image "xxxxxxxxx/cronjobber-updatetz:0.1.1"
  Normal  Created    15s   kubelet, xxxxxxxxx  Created container init-updatetz
  Normal  Started    14s   kubelet, xxxxxxxxx  Started container init-updatetz
  Normal  Pulled     6s    kubelet, xxxxxxxxx  Container image "quay.io/hiddeco/cronjobber:0.2.0" already present on machine
  Normal  Created    6s    kubelet, xxxxxxxxx  Created container cronjobber
  Normal  Started    5s    kubelet, xxxxxxxxx  Started container cronjobber
  Normal  Pulling    5s    kubelet, xxxxxxxxx  Pulling image "xxxxxxxxx/cronjobber-updatetz:0.1.1"
  Normal  Pulled     5s    kubelet, xxxxxxxxx  Successfully pulled image "xxxxxxxxx/cronjobber-updatetz:0.1.1"
  Normal  Created    5s    kubelet, xxxxxxxxx  Created container updatetz
  Normal  Started    5s    kubelet, xxxxxxxxx  Started container updatetz
```

**cronjobber logs**
```
fethi.ozdol$ kubectl logs cronjobber-yyyyyyyyyyyy -c init-updatetz
2020-05-19T18:38:07+0000 Local Time Zone database updated to version 2020a on /tmp/zoneinfo
fethi.ozdol$ kubectl logs cronjobber-yyyyyyyyyyyy -c updatetz
2020-05-19T18:38:11+0000 Local Time Zone database is up to date
fethi.ozdol$ kubectl logs cronjobber-yyyyyyyyyyyy -c cronjobber
W0519 18:38:09.147422       1 client_config.go:548] Neither --kubeconfig nor --master was specified.  Using the inClusterConfig.  This might not work.
{"level":"info","ts":"2020-05-19T18:38:09.158Z","caller":"cronjobber/main.go:64","msg":"Connected to Kubernetes API: v1.14.9-zzzzzzzz"}
{"level":"info","ts":"2020-05-19T18:38:09.158Z","caller":"cronjobber/main.go:75","msg":"Starting Cronjobber version 0.2.0 revision f860bc912c395c58fa72741d8d34e8bf4b1a2c00"}
{"level":"info","ts":"2020-05-19T18:38:09.158Z","caller":"cronjobber/controller.go:106","msg":"Starting TZCronJob Manager"}
```

Note that;
1- init-updatetz updates the local time zone database at 18:38:07
2- updatetz says the local time zone database is already up to date at 18:38:11.
3- cronjobber starts at 18:38:09, which is post init-updatetz