### PR TITLE
Use embedded timezonde db in Go 1.15 as default

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/golang:1.11
+      - image: circleci/golang:1.15
     working_directory: /go/src/github.com/hiddeco/cronjobber
     steps:
       - checkout

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.11
+ARG GO_VERSION=1.15
 
 FROM golang:${GO_VERSION}-alpine AS builder
 

--- a/cmd/cronjobber/main.go
+++ b/cmd/cronjobber/main.go
@@ -5,6 +5,7 @@ import (
 	"k8s.io/klog"
 	"log"
 	"time"
+	_ "time/tzdata"
 
 	clientset "github.com/hiddeco/cronjobber/pkg/client/clientset/versioned"
 	informers "github.com/hiddeco/cronjobber/pkg/client/informers/externalversions"


### PR DESCRIPTION
Workaround for #34 

This embeds a default timezone database into the Go binary. Using the `updatetz` utility is still possible using this approach, but should be disabled until Go has fixed the issue with `slim` formats, as it does not fall back to the embedded database on errors.