### PR TITLE
Implement default values for job history limits

### DIFF
--- a/pkg/controller/cronjobber/controller.go
+++ b/pkg/controller/cronjobber/controller.go
@@ -151,9 +151,13 @@ func (jm *TZCronJobController) syncAll() {
 // cleanupFinishedJobs cleanups finished jobs created by a TZCronJob
 func cleanupFinishedJobs(sj *cronjobberv1.TZCronJob, js []batchv1.Job, jc jobControlInterface,
 	sjc sjControlInterface, recorder record.EventRecorder, logger *zap.SugaredLogger) {
-	// If neither limits are active, there is no need to do anything.
-	if sj.Spec.FailedJobsHistoryLimit == nil && sj.Spec.SuccessfulJobsHistoryLimit == nil {
-		return
+	// According to the documentation and the behaviour of the original cronjob we set the default values:
+	if sj.Spec.FailedJobsHistoryLimit == nil {
+		sj.Spec.FailedJobsHistoryLimit = pointerInt32(1)
+	}
+
+	if sj.Spec.SuccessfulJobsHistoryLimit == nil {
+		sj.Spec.SuccessfulJobsHistoryLimit = pointerInt32(3)
 	}
 
 	failedJobs := []batchv1.Job{}
@@ -168,23 +172,19 @@ func cleanupFinishedJobs(sj *cronjobberv1.TZCronJob, js []batchv1.Job, jc jobCon
 		}
 	}
 
-	if sj.Spec.SuccessfulJobsHistoryLimit != nil {
-		removeOldestJobs(sj,
-			succesfulJobs,
-			jc,
-			*sj.Spec.SuccessfulJobsHistoryLimit,
-			recorder,
-			logger)
-	}
+	removeOldestJobs(sj,
+		succesfulJobs,
+		jc,
+		*sj.Spec.SuccessfulJobsHistoryLimit,
+		recorder,
+		logger)
 
-	if sj.Spec.FailedJobsHistoryLimit != nil {
-		removeOldestJobs(sj,
-			failedJobs,
-			jc,
-			*sj.Spec.FailedJobsHistoryLimit,
-			recorder,
-			logger)
-	}
+	removeOldestJobs(sj,
+		failedJobs,
+		jc,
+		*sj.Spec.FailedJobsHistoryLimit,
+		recorder,
+		logger)
 
 	// Update the TZCronJob, in case jobs were removed from the list.
 	if _, err := sjc.UpdateStatus(sj); err != nil {

--- a/pkg/controller/cronjobber/utils.go
+++ b/pkg/controller/cronjobber/utils.go
@@ -216,3 +216,7 @@ func getCurrentTimeInZone(sj *cronjobberv1.TZCronJob) (time.Time, error) {
 
 	return time.Now().In(loc), nil
 }
+
+func pointerInt32(i int32) *int32 {
+	return &i
+}


### PR DESCRIPTION
According to the documentation of both the cronjob and tzcronjob the defaults are either 1 for failed jobs and 3 for successful jobs. Currently tzCronjobber ignores those defaults completely. 